### PR TITLE
Add setView methods to Camera

### DIFF
--- a/include/Camera.h
+++ b/include/Camera.h
@@ -18,6 +18,7 @@ namespace pbnj {
             void setPosition(float x, float y, float z);
             void setUpVector(float x, float y, float z);
             void setOrbitRadius(float radius);
+            void setView(float x, float y, float z);
             // no longer needed as the volume is centered automatically
             void centerView();
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -47,28 +47,30 @@ void Camera::setPosition(float x, float y, float z)
     this->updateOSPRayPosition();
 }
 
-// no longer needed as the volume is centered automatically
+void Camera::setView(float x, float y, float z)
+{
+    this->viewX = x;
+    this->viewY = y;
+    this->viewZ = z;
+    this->updateOSPRayPosition();
+}
+
 void Camera::centerView()
 {
     //center the camera's viewpoint on the center of a volume
     //std::vector<int> bounds = v->getBounds();
-    this->viewX = 0; //(float)(bounds[0])/2.0;
-    this->viewY = 0; //(float)(bounds[1])/2.0;
-    this->viewZ = 0; //(float)(bounds[2])/2.0;
+    this->viewX = -this->xPos; //(float)(bounds[0])/2.0;
+    this->viewY = -this->yPos; //(float)(bounds[1])/2.0;
+    this->viewZ = -this->zPos; //(float)(bounds[2])/2.0;
 }
 
 void Camera::updateOSPRayPosition()
 {
-    //calculate the components for the view vector
-    float deltaX = (this->viewX-this->xPos);
-    float deltaY = (this->viewY-this->yPos);
-    float deltaZ = (this->viewZ-this->zPos);
-
     //update OSPRay camera
     float position[] = {this->xPos, this->yPos, this->zPos};
     ospSet3fv(this->oCamera, "pos", position);
 
-    float direction[] = {deltaX, deltaY, deltaZ};
+    float direction[] = {this->viewX, this->viewY, this->viewZ};
     ospSet3fv(this->oCamera, "dir", direction);
 
     float up[] = {this->upX, this->upY, this->upZ};


### PR DESCRIPTION
Related to seelabutk/enchiladas#3. Should be merged when that other pull request is merged.

Previously, the view direction was hardcoded and made to always be towards the center of the object. With some of the work in Alpaca, I needed to be able to control the look direction. This pull request adds a single setView method and updates the existing implementation of `centerView`.

To update existing code to use the new implementation, the main thing is to ensure that `centerView` is called (because it previously wasn't needed). Similarly, if manually calling `setView` and wanting the old behavior, set the `vx`, `vy`, and `vz` parameters to the negatives of the position `x`, `y`, `z`, i.e.:

```c++
void foo(void) {
    pbnj::Camera *camera = new pbnj::Camera(256, 256);
    camera->setPosition(10, 20, 30);
    camera->setUpVector(0, 0, 1);

    // these next two lines are equivalent and one should be added for the old behavior
    camera->setView(-10, -20, -30);
    camera->centerView();

    // ...
}
```