### PR TITLE
added alpha to background color

### DIFF
--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -17,7 +17,7 @@ namespace pbnj {
             Renderer();
             ~Renderer();
 
-            void setBackgroundColor(unsigned char r, unsigned char g, unsigned char b);
+            void setBackgroundColor(unsigned char r, unsigned char g, unsigned char b, unsigned char a);
             void setBackgroundColor(std::vector<unsigned char> bgColor);
             void setVolume(Volume *v);
             void addLight();
@@ -34,7 +34,7 @@ namespace pbnj {
             int cameraWidth;
             int cameraHeight;
         private:
-            unsigned char backgroundColor[3];
+            unsigned char backgroundColor[4];
 
             OSPRenderer oRenderer;
             OSPFrameBuffer oFrameBuffer;


### PR DESCRIPTION
backgroundColor in the config file can now be either RGB or RGBA
If it's RGB, alpha will be set to 255, otherwise the given alpha will be
used. If alpha is set to 0, the image will not be composited onto the
background to minimize background color seep
Default background is transparent black

only PNG compositing will work as PPM doesn't have an alpha channel