### PR TITLE
potential fix for larger datasets

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -26,10 +26,10 @@ namespace pbnj {
             std::string filename;
             FILETYPE filetype;
 
-            int xDim;
-            int yDim;
-            int zDim;
-            long int numValues;
+            unsigned long int xDim;
+            unsigned long int yDim;
+            unsigned long int zDim;
+            unsigned long int numValues;
 
             float minVal; // these should 
             float maxVal; //

--- a/include/Volume.h
+++ b/include/Volume.h
@@ -24,7 +24,7 @@ namespace pbnj {
             void attenuateOpacity(float amount);
             void setColorMap(std::vector<float> &map);
             void setOpacityMap(std::vector<float> &map);
-            std::vector<int> getBounds();
+            std::vector<long unsigned int> getBounds();
             OSPVolume asOSPRayObject();
 
             std::string ID;

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -22,6 +22,11 @@ namespace pbnj {
 DataFile::DataFile(int x, int y, int z) :
     xDim(x), yDim(y), zDim(z), numValues(x*y*z), statsCalculated(false)
 {
+    this->numValues = xDim * yDim * zDim;
+    std::cerr << "DEBUG x: " << xDim << std::endl;
+    std::cerr << "DEBUG y: " << yDim << std::endl;
+    std::cerr << "DEBUG z: " << zDim << std::endl;
+    std::cerr << "DEBUG numValues: " << numValues << std::endl;
 }
 
 DataFile::~DataFile()
@@ -65,9 +70,9 @@ void DataFile::loadFromFile(std::string filename, std::string var_name,
         }
 
         // overwrite any configured values with the file's values
-        this->xDim = (int) variable.getDim(2).getSize();
-        this->yDim = (int) variable.getDim(1).getSize();
-        this->zDim = (int) variable.getDim(0).getSize();
+        this->xDim = (long unsigned int) variable.getDim(2).getSize();
+        this->yDim = (long unsigned int) variable.getDim(1).getSize();
+        this->zDim = (long unsigned int) variable.getDim(0).getSize();
         this->numValues = this->xDim * this->yDim * this->zDim;
 
         // load data
@@ -91,6 +96,13 @@ void DataFile::loadFromFile(std::string filename, std::string var_name,
             }
             else {
                 this->data = (float *)malloc(this->numValues * sizeof(float));
+                if(this->data == MAP_FAILED) {
+                    switch(errno) {
+                        case ENOMEM:
+                            std::cerr << "ENOMEM out of memory" << std::endl;
+                            break;
+                    }
+                }
                 size_t bytes = fread(this->data, sizeof(float), this->numValues,
                         dataFile);
             }

--- a/src/Volume.cpp
+++ b/src/Volume.cpp
@@ -95,10 +95,10 @@ void Volume::setOpacityMap(std::vector<float> &map)
     this->transferFunction->setOpacityMap(map);
 }
 
-std::vector<int> Volume::getBounds()
+std::vector<long unsigned int> Volume::getBounds()
 {
-    std::vector<int> bounds = {this->dataFile->xDim, this->dataFile->yDim,
-        this->dataFile->zDim};
+    std::vector<long unsigned int> bounds = {this->dataFile->xDim,
+        this->dataFile->yDim, this->dataFile->zDim};
     return bounds;
 }
 

--- a/src/test/simpleVolumeRender.cpp
+++ b/src/test/simpleVolumeRender.cpp
@@ -56,7 +56,7 @@ int main(int argc, const char **argv)
         case pbnj::SINGLE_NOVAR:
             std::cout << "Single volume, no variable" << std::endl;
             volume = new pbnj::Volume(config->dataFilename, config->dataXDim,
-                    config->dataYDim, config->dataZDim);
+                    config->dataYDim, config->dataZDim, true);
             break;
         case pbnj::SINGLE_VAR:
             std::cout << "Single volume, variable" << std::endl;


### PR DESCRIPTION
error caused by integer overflow when calculating the number of values
in a volume. Switched everything to long unsigned int

This causes warnings in Volume.cpp though because there is a narrowing
conversion from long unsigned int to const int