### PR TITLE
Added support for non-file configurations

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -2,6 +2,7 @@
 #define PBNJ_CONFIGURATION_H
 
 #include <ConfigReader.h>
+#include "rapidjson/document.h"
 
 #include <string>
 #include <vector>
@@ -14,10 +15,8 @@ namespace pbnj {
     class Configuration {
 
         public:
-            Configuration(std::string filename);
+            Configuration(rapidjson::Document& json);
             CONFSTATE getConfigState();
-
-            std::string configFilename;
 
             std::string dataFilename;
             std::vector<std::string> globbedFilenames;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -11,14 +11,8 @@
 
 namespace pbnj {
 
-Configuration::Configuration(std::string filename) :
-    configFilename(filename)
+Configuration::Configuration(rapidjson::Document& json)
 {
-    //get a parsed json document from the file
-    this->reader = new ConfigReader();
-    rapidjson::Document json;
-    this->reader->parseConfigFile(filename, json);
-
     /* the following are required:
      *  - data filename
      *  - data dimensions <- should be required only for raw

--- a/src/test/benchmark.cpp
+++ b/src/test/benchmark.cpp
@@ -6,6 +6,7 @@
 #include "Volume.h"
 
 #include "lodepng/lodepng.h"
+#include "rapidjson/document.h"
 
 #include <chrono>
 #include <fstream>
@@ -35,7 +36,10 @@ int main(int argc, const char **argv)
         png_benchmark = true;
 
     // pbnj and volume initialization
-    pbnj::Configuration *config = new pbnj::Configuration(argv[1]);
+    pbnj::ConfigReader *reader = new pbnj::ConfigReader();
+    rapidjson::Document json;
+    reader->parseConfigFile(argv[1], json);
+    pbnj::Configuration *config = new pbnj::Configuration(json);
     pbnj::pbnjInit(&argc, argv);
     pbnj::Volume *volume = new pbnj::Volume(config->dataFilename,
             config->dataXDim, config->dataYDim, config->dataZDim);

--- a/src/test/omni.cpp
+++ b/src/test/omni.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <stdlib.h>
 #include "lodepng/lodepng.h"
+#include "rapidjson/document.h"
 #include <string>
 #include <vector>
 
@@ -96,7 +97,10 @@ int main(int argc, const char **argv)
     std::string confFile(argv[1]);
     std::string confName = confFile.substr(confFile.rfind('/')+1);
     confName = confName.substr(0, confName.rfind('.'));
-    pbnj::Configuration *config = new pbnj::Configuration(argv[1]);
+    pbnj::ConfigReader *reader = new pbnj::ConfigReader();
+    rapidjson::Document json;
+    reader->parseConfigFile(argv[1], json);
+    pbnj::Configuration *config = new pbnj::Configuration(json);
     pbnj::pbnjInit(&argc, argv);
 
     pbnj::CONFSTATE confState = config->getConfigState();

--- a/src/test/pbnjTest.cpp
+++ b/src/test/pbnjTest.cpp
@@ -6,6 +6,7 @@
 #include "Volume.h"
 
 #include "pbnj.h"
+#include "rapidjson/document.h"
 
 #include <iostream>
 
@@ -14,8 +15,10 @@ int main(int argc, const char **argv) {
 
 #if 1
 
-    pbnj::Configuration *config = new pbnj::Configuration(
-            "../configs/turbulence.json");
+    pbnj::ConfigReader *reader = new pbnj::ConfigReader();
+    rapidjson::Document json;
+    reader->parseConfigFile("../configs/turbulence.json", json);
+    pbnj::Configuration *config = new pbnj::Configuration(json);
 
     // initialization has to go after configuration!
     // otherwise it causes a segfault in OSPRay

--- a/src/test/simpleVolumeRender.cpp
+++ b/src/test/simpleVolumeRender.cpp
@@ -27,7 +27,10 @@ int main(int argc, const char **argv)
         return 1;
     }
 
-    pbnj::Configuration *config = new pbnj::Configuration(argv[1]);
+    pbnj::ConfigReader *reader = new pbnj::ConfigReader();
+    rapidjson::Document json;
+    reader->parseConfigFile(argv[1], json);
+    pbnj::Configuration *config = new pbnj::Configuration(json);
 
     pbnj::pbnjInit(&argc, argv);
 

--- a/src/test/timeSeries.cpp
+++ b/src/test/timeSeries.cpp
@@ -5,6 +5,7 @@
 #include "TimeSeries.h"
 #include "TransferFunction.h"
 #include "Volume.h"
+#include "rapidjson/document.h"
 
 #include <iostream>
 #include <sys/sysinfo.h>
@@ -21,7 +22,10 @@ int main(int argc, const char **argv)
         return 1;
     }
 
-    pbnj::Configuration *config = new pbnj::Configuration(argv[1]);
+    pbnj::ConfigReader *reader = new pbnj::ConfigReader();
+    rapidjson::Document json;
+    reader->parseConfigFile(argv[1], json);
+    pbnj::Configuration *config = new pbnj::Configuration(json);
     pbnj::pbnjInit(&argc, argv);
 
     pbnj::TimeSeries *timeSeries;


### PR DESCRIPTION
In order to support hot reloading of configurations as well as adding new configurations at runtime in Enchiladas and Tapestry, there is a need to support setting configurations without files necessarily existing. 

In this pull request, Configuration no longer takes a filename. Instead it takes a json. ConfigReader still takes a filename and parses a json. Therefore, all places that used Configuration in the project now parse the file themselves using ConfigReader, then give it to Configuration();

pls accept this pull request!!