### PR TITLE
Component support for datasets

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -24,6 +24,7 @@ namespace pbnj {
             int dataXDim;
             int dataYDim;
             int dataZDim;
+            unsigned int dataNumComponents;
 
             int imageWidth;
             int imageHeight;

--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -12,7 +12,7 @@ namespace pbnj {
     class DataFile {
 
         public:
-            DataFile(int x, int y, int z);
+            DataFile(int x, int y, int z, unsigned int components=1);
             ~DataFile();
 
             void loadFromFile(std::string filename, std::string variable="",
@@ -30,6 +30,7 @@ namespace pbnj {
             unsigned long int yDim;
             unsigned long int zDim;
             unsigned long int numValues;
+            unsigned int numComponents;
 
             float minVal; // these should 
             float maxVal; //

--- a/include/TimeSeries.h
+++ b/include/TimeSeries.h
@@ -13,9 +13,9 @@ namespace pbnj {
     class TimeSeries {
 
         public:
-            TimeSeries(std::vector<std::string> filenames, int x, int y, int z);
+            TimeSeries(std::vector<std::string> filenames, int x, int y, int z, unsigned int components=1);
             TimeSeries(std::vector<std::string> filenames, std::string varname,
-                    int x, int y, int z);
+                    int x, int y, int z, unsigned int components=1);
             ~TimeSeries();
 
             Volume *getVolume(unsigned int index);
@@ -38,6 +38,7 @@ namespace pbnj {
             int xDim;
             int yDim;
             int zDim;
+            unsigned int numComponents;
             unsigned int dataSize;
             unsigned int maxVolumes;
             unsigned int currentVolumes;

--- a/include/Volume.h
+++ b/include/Volume.h
@@ -16,9 +16,9 @@ namespace pbnj {
         public:
             //Volume(DataFile *df);
             Volume(std::string filename, int x, int y, int z,
-                    bool memmap=false);
+                    bool memmap=false, unsigned int components=1);
             Volume(std::string filename, std::string var_name, int x, int y,
-                    int z, bool memmap=false);
+                    int z, bool memmap=false, unsigned int components=1);
             ~Volume();
 
             void attenuateOpacity(float amount);

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -192,7 +192,7 @@ Configuration::Configuration(rapidjson::Document& json)
     // number of data components
     // defaults to 1 in DataFile if not used
     if(json.HasMember("components")) {
-        this->dataNumComponents = json["components"].GetInt();
+        this->dataNumComponents = json["components"].GetUint();
     }
     else {
         this->dataNumComponents = 1;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -188,6 +188,15 @@ Configuration::Configuration(rapidjson::Document& json)
     else {
         this->specularity = 0.1;
     }
+
+    // number of data components
+    // defaults to 1 in DataFile if not used
+    if(json.HasMember("components")) {
+        this->dataNumComponents = json["components"].GetInt();
+    }
+    else {
+        this->dataNumComponents = 1;
+    }
 }
 
 void Configuration::selectColorMap(std::string userInput)

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -87,9 +87,28 @@ void DataFile::loadFromFile(std::string filename, std::string var_name,
         }
         else {
             if(memmap) {
-                int fd = fileno(dataFile);
-                this->data = (float *)mmap(NULL, this->numValues*sizeof(float),
-                        PROT_READ, MAP_SHARED, fd, 0);
+                if(this->numComponents == 1) {
+                    int fd = fileno(dataFile);
+                    this->data = (float *)mmap(NULL, this->numValues*sizeof(float),
+                            PROT_READ, MAP_SHARED, fd, 0);
+                }
+                else {
+                    this->data = (float *)malloc(this->numValues * sizeof(float));
+                    if(this->data == MAP_FAILED) {
+                        switch(errno) {
+                            case ENOMEM:
+                                std::cerr << "ENOMEM out of memory" << std::endl;
+                                break;
+                        }
+                    }
+                    float *chunk = (float *)malloc(this->numComponents*sizeof(float));
+                    for(int i = 0; i < this->numValues; i++) {
+                        size_t numbytes = fread(chunk, sizeof(float),
+                                this->numComponents, dataFile);
+                        this->data[i] = std::sqrt(chunk[0]*chunk[0] +
+                                chunk[1]*chunk[1] + chunk[2]*chunk[2]);
+                    }
+                }
             }
             else {
                 this->data = (float *)malloc(this->numValues * sizeof(float));

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -19,8 +19,9 @@
 
 namespace pbnj {
 
-DataFile::DataFile(int x, int y, int z) :
-    xDim(x), yDim(y), zDim(z), numValues(x*y*z), statsCalculated(false)
+DataFile::DataFile(int x, int y, int z, unsigned int components) :
+    xDim(x), yDim(y), zDim(z), numValues(x*y*z), statsCalculated(false),
+    numComponents(components)
 {
     this->numValues = xDim * yDim * zDim;
 }
@@ -99,8 +100,19 @@ void DataFile::loadFromFile(std::string filename, std::string var_name,
                             break;
                     }
                 }
-                size_t bytes = fread(this->data, sizeof(float), this->numValues,
-                        dataFile);
+                if(this->numComponents == 1) {
+                    size_t bytes = fread(this->data, sizeof(float),
+                            this->numValues, dataFile);
+                }
+                else {
+                    float *chunk = (float *)malloc(this->numComponents*sizeof(float));
+                    for(int i = 0; i < this->numValues; i++) {
+                        size_t numbytes = fread(chunk, sizeof(float),
+                                this->numComponents, dataFile);
+                        this->data[i] = std::sqrt(chunk[0]*chunk[0] +
+                                chunk[1]*chunk[1] + chunk[2]*chunk[2]);
+                    }
+                }
             }
             fclose(dataFile);
         }

--- a/src/TimeSeries.cpp
+++ b/src/TimeSeries.cpp
@@ -24,7 +24,7 @@ TimeSeries::TimeSeries(std::vector<std::string> filenames,
 TimeSeries::TimeSeries(std::vector<std::string> filenames,
         std::string varname, int x, int y, int z, unsigned int components) :
     dataFilenames(filenames), length(filenames.size()), dataVariable(varname),
-    xDim(x), yDim(y), zDim(z), dataSize(x*y*z*4)
+    xDim(x), yDim(y), zDim(z), dataSize(x*y*z*4), numComponents(components)
 {
     this->volumes = new Volume*[this->length];
     for(int i = 0; i < this->length; i++)

--- a/src/TimeSeries.cpp
+++ b/src/TimeSeries.cpp
@@ -8,9 +8,9 @@
 namespace pbnj {
 
 TimeSeries::TimeSeries(std::vector<std::string> filenames,
-        int x, int y, int z) :
+        int x, int y, int z, unsigned int components) :
     dataFilenames(filenames), length(filenames.size()), xDim(x), yDim(y),
-    zDim(z), dataSize(x*y*z*4)
+    zDim(z), dataSize(x*y*z*4), numComponents(components)
 {
     this->volumes = new Volume*[this->length];
     for(int i = 0; i < this->length; i++)
@@ -22,7 +22,7 @@ TimeSeries::TimeSeries(std::vector<std::string> filenames,
 }
 
 TimeSeries::TimeSeries(std::vector<std::string> filenames,
-        std::string varname, int x, int y, int z) :
+        std::string varname, int x, int y, int z, unsigned int components) :
     dataFilenames(filenames), length(filenames.size()), dataVariable(varname),
     xDim(x), yDim(y), zDim(z), dataSize(x*y*z*4)
 {
@@ -110,11 +110,12 @@ Volume *TimeSeries::getVolume(unsigned int index)
         // load the volume
         if(this->dataVariable.empty())
             this->volumes[index] = new Volume(this->dataFilenames[index],
-                    this->xDim, this->yDim, this->zDim, this->doMemoryMap);
+                    this->xDim, this->yDim, this->zDim, this->doMemoryMap,
+                    this->numComponents);
         else
             this->volumes[index] = new Volume(this->dataFilenames[index],
                     this->dataVariable, this->xDim, this->yDim, this->zDim,
-                    this->doMemoryMap);
+                    this->doMemoryMap, this->numComponents);
 
         // set any given attributes
         if(!this->colorMap.empty())

--- a/src/Volume.cpp
+++ b/src/Volume.cpp
@@ -8,24 +8,25 @@
 
 namespace pbnj {
 
-Volume::Volume(std::string filename, int x, int y, int z, bool memmap)
+Volume::Volume(std::string filename, int x, int y, int z, bool memmap,
+        unsigned int components)
 {
     this->ID = createID();
     //volumes contain a datafile
     //one datafile per volume, one volume per renderer/camera
-    this->dataFile = new DataFile(x, y, z);
+    this->dataFile = new DataFile(x, y, z, components);
     this->loadFromFile(filename, "", memmap);
 
     this->init();
 }
 
 Volume::Volume(std::string filename, std::string var_name, int x, int y, int z,
-        bool memmap)
+        bool memmap, unsigned int components)
 {
     this->ID = createID();
     //volumes contain a datafile
     //one datafile per volume, one volume per renderer/camera
-    this->dataFile = new DataFile(x, y, z);
+    this->dataFile = new DataFile(x, y, z, components);
     this->loadFromFile(filename, var_name, memmap);
 
     this->init();

--- a/src/test/simpleVolumeRender.cpp
+++ b/src/test/simpleVolumeRender.cpp
@@ -59,18 +59,19 @@ int main(int argc, const char **argv)
         case pbnj::SINGLE_NOVAR:
             std::cout << "Single volume, no variable" << std::endl;
             volume = new pbnj::Volume(config->dataFilename, config->dataXDim,
-                    config->dataYDim, config->dataZDim, true);
+                    config->dataYDim, config->dataZDim, true, config->dataNumComponents);
             break;
         case pbnj::SINGLE_VAR:
             std::cout << "Single volume, variable" << std::endl;
             volume = new pbnj::Volume(config->dataFilename,
                     config->dataVariable, config->dataXDim, config->dataYDim,
-                    config->dataZDim);
+                    config->dataZDim, config->dataNumComponents);
             break;
         case pbnj::MULTI_NOVAR:
             std::cout << "Multiple volumes, no variable" << std::endl;
             timeSeries = new pbnj::TimeSeries(config->globbedFilenames,
-                    config->dataXDim, config->dataYDim, config->dataZDim);
+                    config->dataXDim, config->dataYDim, config->dataZDim,
+                    config->dataNumComponents);
             timeSeries->setColorMap(config->colorMap);
             timeSeries->setOpacityMap(config->opacityMap);
             timeSeries->setOpacityAttenuation(config->opacityAttenuation);
@@ -81,7 +82,7 @@ int main(int argc, const char **argv)
             std::cout << "Multiple volumes, variable" << std::endl;
             timeSeries = new pbnj::TimeSeries(config->globbedFilenames,
                     config->dataVariable, config->dataXDim, config->dataYDim,
-                    config->dataZDim);
+                    config->dataZDim, config->dataNumComponents);
             timeSeries->setColorMap(config->colorMap);
             timeSeries->setOpacityMap(config->opacityMap);
             timeSeries->setOpacityAttenuation(config->opacityAttenuation);


### PR DESCRIPTION
First in a long list of branches that have been in-flight for a year.

Adds support for volumes that have multiple components (i.e. contain vector data). The number of components is specified in the config file with `"components": <int>`, which defaults to 1 if not included. When a `DataFile`'s `numComponents` > 1, the vector data is converted to scalar by computing the vector magnitude. After reading, the data layout is identical to volumes with scalar data to begin with.

Works for memory-mapped and non-memory-mapped binary files, but does _not_ work for NetCDF files. NetCDF support is tenuous at best and so needs a lot of attention on its own.